### PR TITLE
1.0.0a6

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge/label/jupyterlab_rc,conda-forge/label/jupyterlab_server_rc,conda-forge,defaults
 channel_targets:

--- a/build-locally.py
+++ b/build-locally.py
@@ -61,7 +61,7 @@ def main(args=None):
         help="Setup debug environment using `conda debug`",
     )
     p.add_argument(
-        "--output-id", help="If running debug, specifiy the output to setup."
+        "--output-id", help="If running debug, specify the output to setup."
     )
 
     ns = p.parse_args(args=args)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.0a5" %}
-{% set sha256 = "6435eb4df6f9c63533dadd9d2d4cca280bf28a22f0b94627b6ddbcdea6db2384" %}
+{% set version = "1.0.0a6" %}
+{% set sha256 = "d96f219cb3a6832384a324e36a603c6c6462a878577e11f8b5256bb73c00b2fb" %}
 
 package:
   name: jupyterlab_widgets
@@ -21,6 +21,8 @@ requirements:
 
   run:
     - python >=3.6
+
+  run_constrained:
     - jupyterlab >=3.0.0rc4,<4
 
 test:


### PR DESCRIPTION
This removes the jupyterlab dependency, but we still have a run constraint. See https://github.com/jupyter-widgets/ipywidgets/pull/2995

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
