### PR TITLE
Remove the run_constrained requirement for jlab.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/j/jupyterlab_widgets/jupyterlab_widgets-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -21,9 +21,6 @@ requirements:
 
   run:
     - python >=3.6
-
-  run_constrained:
-    - jupyterlab >=3.0.0,<4
 
 test:
   imports:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/ipywidgets-feedstock/issues/65

Since jupyterlab_widgets is now installed by default with ipywidgets, having this run_constrained line in would insist that ipywidgets cannot be used with jlab 2, which is overreaching.

For now, it seems that consensus is that it is better to have the dependency between ipywidgets and jupyterlab_widgets (making things much more convenient for users) than having things more pure from a dependency standpoint.

We may change our mind in the future, though. For example, when jupyterlab_widgets is upgraded to support jlab 4, then blindly installing jupyterlab_widgets may not work for jlab 3, unless we do some work to support both jlab 3 and jlab 4 in the same package.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
